### PR TITLE
small fix for Leader role handover

### DIFF
--- a/etcd-discovery/src/main/scala/pl/caltha/akka/cluster/ClusterDiscoveryActor.scala
+++ b/etcd-discovery/src/main/scala/pl/caltha/akka/cluster/ClusterDiscoveryActor.scala
@@ -125,7 +125,7 @@ class ClusterDiscoveryActor(
   onTransition {
     case (_, Follower) ⇒
       log.info("assuming Follower role")
-      cluster.subscribe(self, initialStateMode = InitialStateAsSnapshot, classOf[MemberEvent])
+      cluster.subscribe(self, initialStateMode = InitialStateAsSnapshot, classOf[ClusterDomainEvent])
       setTimer("seedsFetch", SeedsFetchTimeout, settings.seedsFetchTimeout, false)
       fetchSeeds()
   }


### PR DESCRIPTION
ClusterDiscoveryActor should listen ClusterDomainEvent rather than MemberEvent when it is Follwer because LeaderChanged event is not MemberEvent.
